### PR TITLE
Apply template on dashboard_2

### DIFF
--- a/src/app/(test)/dashboard_2/template.tsx
+++ b/src/app/(test)/dashboard_2/template.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function DashBoard_2_Template({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    console.log("DashBoard_2_Template useEffect");
+    return () => {
+      console.log("DashBoard_2_Template cleanup");
+    };
+  });
+  return <div>{children}</div>;
+}

--- a/src/app/(test)/layout.tsx
+++ b/src/app/(test)/layout.tsx
@@ -1,9 +1,18 @@
-import Link from "next/link";
+"use client";
+
+import { useEffect } from "react";
 
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  useEffect(() => {
+    console.log("DashboardLayout useEffect");
+    return () => {
+      console.log("DashboardLayout cleanup");
+    };
+  });
+
   return <section className="grid place-items-center">{children}</section>;
 }


### PR DESCRIPTION
### スクリーンショット	

https://github.com/coppepam/app_router_tutorial/assets/2876839/ddd486e9-fa88-415c-9706-85a5eb453ff6


### 内容説明
テストとしてdashboard_2 にだけ template を適用してみる
grid の対象が １つのdivになったことで、スクショのようにくずれることと
layoutと違い、templateのみがrerenderされることを確認できた